### PR TITLE
feat(adapters): Add passthrough adapter for message listening

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,9 @@ src/thenvoi_cli/
 │   ├── run.py          # Run agent with adapter (Agent API)
 │   ├── status.py       # Agent status/stop commands
 │   └── test.py         # Connectivity testing
+├── adapters/           # Built-in adapters (no external deps)
+│   └── passthrough.py  # Output messages to stdout as JSON
+├── adapter_registry.py # Adapter discovery and loading
 ├── config_manager.py   # YAML config file handling
 ├── sdk_client.py       # SDK wrapper for Agent API operations
 ├── output.py           # Output formatting (JSON/table/plain)
@@ -93,7 +96,11 @@ thenvoi-cli participants remove ROOM_ID PEER_ID --agent NAME
 thenvoi-cli peers --agent NAME       # Discover peer agents
 thenvoi-cli test NAME                # Test connectivity
 thenvoi-cli adapters list            # List framework adapters
-thenvoi-cli run NAME --adapter TYPE  # Run agent (needs full SDK)
+thenvoi-cli run NAME --adapter TYPE  # Run agent with adapter
+
+# Passthrough adapter (no LLM, outputs messages to stdout)
+thenvoi-cli run my-agent --adapter passthrough
+thenvoi-cli run my-agent --adapter passthrough | ./process-messages.py
 ```
 
 ## Environment Variables
@@ -144,8 +151,22 @@ pyinstaller thenvoi-cli.spec
 ## Key Files to Modify
 
 - Adding new commands: Create in `src/thenvoi_cli/commands/`, register in `cli.py`
+- Adding new adapters: Create in `src/thenvoi_cli/adapters/`, register in `adapter_registry.py`
 - API changes: Update `commands/agents.py` (User API) or `sdk_client.py` (Agent API)
 - Output formatting: See `output.py` for `OutputFormat` enum and helpers
 - Config handling: See `config_manager.py` for YAML operations
 - Binary build: See `thenvoi-cli.spec` for PyInstaller configuration
 - CI/CD: See `.github/workflows/release.yml` for binary build pipeline
+
+## Adapters
+
+Adapters connect agents to LLM backends or other processing. Most require optional dependencies, but some are built-in:
+
+| Adapter | Description | Dependencies |
+|---------|-------------|--------------|
+| `passthrough` | Output messages to stdout as JSON (no LLM) | None (built-in) |
+| `langgraph` | LangGraph ReAct agent | `thenvoi-sdk[langgraph]` |
+| `anthropic` | Anthropic Claude SDK | `thenvoi-sdk[anthropic]` |
+| `claude-sdk` | Claude Agent SDK | `thenvoi-sdk[claude-sdk]` |
+
+The `passthrough` adapter is useful for orchestration systems that need to listen for messages and trigger external processes without LLM processing.

--- a/src/thenvoi_cli/adapter_registry.py
+++ b/src/thenvoi_cli/adapter_registry.py
@@ -99,6 +99,15 @@ ADAPTERS: dict[str, AdapterInfo] = {
         default_model=None,
         env_vars=[],
     ),
+    "passthrough": AdapterInfo(
+        name="passthrough",
+        class_name="PassthroughAdapter",
+        module="thenvoi_cli.adapters.passthrough",
+        description="Output messages to stdout without LLM processing",
+        required_deps=[],
+        default_model=None,
+        env_vars=[],
+    ),
 }
 
 

--- a/src/thenvoi_cli/adapters/__init__.py
+++ b/src/thenvoi_cli/adapters/__init__.py
@@ -1,0 +1,5 @@
+"""Built-in CLI adapters."""
+
+from thenvoi_cli.adapters.passthrough import PassthroughAdapter
+
+__all__ = ["PassthroughAdapter"]

--- a/src/thenvoi_cli/adapters/passthrough.py
+++ b/src/thenvoi_cli/adapters/passthrough.py
@@ -1,0 +1,102 @@
+"""Passthrough adapter for message listening without LLM processing."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from thenvoi.core.protocols import AgentToolsProtocol
+    from thenvoi.core.types import AgentInput, PlatformMessage
+
+
+class PassthroughAdapter:
+    """
+    Adapter that outputs messages to stdout without LLM processing.
+
+    Useful for:
+    - Orchestration systems that listen for messages and trigger external actions
+    - Piping messages to external scripts for processing
+    - Debugging and monitoring message flow
+
+    Example:
+        thenvoi-cli run my-agent --adapter passthrough
+        thenvoi-cli run my-agent --adapter passthrough | ./process-messages.py
+
+    Output format (JSON, one per line):
+        {"room_id": "...", "sender": "...", "content": "...", ...}
+    """
+
+    def __init__(self, output_format: str = "json") -> None:
+        """
+        Initialize the passthrough adapter.
+
+        Args:
+            output_format: Output format ("json" or "plain"). Defaults to "json".
+        """
+        self.output_format = output_format
+        self.agent_name: str = ""
+        self.agent_description: str = ""
+
+    async def on_event(self, inp: "AgentInput") -> None:
+        """
+        Process incoming message by outputting to stdout.
+
+        Args:
+            inp: AgentInput containing the message and context.
+        """
+        self._output_message(inp.msg, inp.room_id)
+
+    async def on_message(
+        self,
+        msg: "PlatformMessage",
+        tools: "AgentToolsProtocol",
+        history: Any,
+        participants_msg: str | None,
+        *,
+        is_session_bootstrap: bool,
+        room_id: str,
+    ) -> None:
+        """
+        Handle incoming message by outputting to stdout.
+
+        This method is called by SimpleAdapter-style wrappers.
+
+        Args:
+            msg: The platform message.
+            tools: Agent tools (unused - no responses sent).
+            history: Message history (unused).
+            participants_msg: Participant update message (unused).
+            is_session_bootstrap: Whether this is the first message in session.
+            room_id: The room identifier.
+        """
+        self._output_message(msg, room_id)
+
+    def _output_message(self, msg: "PlatformMessage", room_id: str) -> None:
+        """Output a message to stdout."""
+        if self.output_format == "json":
+            output = {
+                "id": msg.id,
+                "room_id": room_id,
+                "sender_id": msg.sender_id,
+                "sender_name": msg.sender_name,
+                "sender_type": msg.sender_type,
+                "content": msg.content,
+                "message_type": msg.message_type,
+                "timestamp": msg.created_at.isoformat(),
+            }
+            print(json.dumps(output), file=sys.stdout, flush=True)
+        else:
+            # Plain text format
+            sender = msg.sender_name or msg.sender_type or "Unknown"
+            print(f"[{room_id}] {sender}: {msg.content}", file=sys.stdout, flush=True)
+
+    async def on_cleanup(self, room_id: str) -> None:
+        """Clean up when leaving a room (no-op for passthrough)."""
+        pass
+
+    async def on_started(self, agent_name: str, agent_description: str) -> None:
+        """Called after agent starts."""
+        self.agent_name = agent_name
+        self.agent_description = agent_description

--- a/src/thenvoi_cli/commands/run.py
+++ b/src/thenvoi_cli/commands/run.py
@@ -310,6 +310,9 @@ def _create_adapter_instance(
     elif adapter_name == "a2a-gateway":
         return adapter_class()
 
+    elif adapter_name == "passthrough":
+        return adapter_class()
+
     else:
         # Default: try to instantiate with model
         try:

--- a/thenvoi-cli.spec
+++ b/thenvoi-cli.spec
@@ -25,6 +25,8 @@ a = Analysis(
         'thenvoi_cli.commands.agents',
         'thenvoi_cli.config_manager',
         'thenvoi_cli.adapter_registry',
+        'thenvoi_cli.adapters',
+        'thenvoi_cli.adapters.passthrough',
         'thenvoi_cli.sdk_client',
         'thenvoi_cli.process_manager',
         'thenvoi_cli.output',


### PR DESCRIPTION
## Summary

- Add `passthrough` adapter that outputs messages to stdout as JSON without LLM processing
- Enables orchestration/automation use cases where agents listen for messages and trigger external processes
- No external dependencies required - works with the base CLI binary
- Fix `rooms send` command to properly resolve mention names to IDs

## Usage

```bash
# Listen and output messages as JSON to stdout
thenvoi-cli run my-agent --adapter passthrough

# Output:
# {"id": "...", "room_id": "...", "sender_name": "User", "content": "Hello", ...}

# Pipe to external script
thenvoi-cli run my-agent --adapter passthrough | ./process-messages.py
```

## Changes

### Passthrough Adapter
- Add `PassthroughAdapter` class in `thenvoi_cli/adapters/`
- Register in adapter_registry with no dependencies
- Add case in `run.py` for adapter instantiation
- Update PyInstaller spec to include new module

### Rooms Send Fix
- Fix mention resolution in `rooms send` command
- Work around SDK participant cache bug by fetching participants and resolving names to IDs in the CLI
- Pass pre-resolved `{"id": ..., "name": ...}` dicts which the SDK uses directly

## Test plan

- [x] Verify adapter imports correctly
- [x] Verify adapter registry lists passthrough with "Ready: Yes"
- [x] Verify `rooms send` resolves mentions correctly
- [x] Test sending messages via CLI to real room
- [ ] Integration test: run with passthrough adapter against live platform

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)